### PR TITLE
Update useTargetRef example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Use `useTargetRef` to create a custom target ref.
 const Teleporter = createTeleporter()
 
 function CustomTarget() {
-  const targetRef = useTargetRef()
+  const targetRef = Teleporter.useTargetRef()
   return <div ref={targetRef} />
 }
 ```


### PR DESCRIPTION
## Summary

It seems that `useTargetRef` should be `Teleporter.useTargetRef`. I haven't tried this out. I just looked at the code and saw that `useTargetRef` is returned when calling `createTeleporter`.

## Test plan

The example looks correct and would work if it was actually executed (although I haven't executed the example code myself).